### PR TITLE
Remove repo-url from metainfo

### DIFF
--- a/META.info
+++ b/META.info
@@ -8,6 +8,5 @@
     "depends"     : ["Testing"],
     "source-type" : "git",
     "source-url"  : "git://github.com/colomon/io-prompter.git",
-    "repo-type"   : "git",
-    "repo-url"    : "git://github.com/colomon/io-prompter.git"
+    "repo-type"   : "git"
 }


### PR DESCRIPTION
The `repo-url` metainfo property has been obsolete for some time and has
largely been replaced by `source-url`.  Since the metainfo here already uses
`source-url` only the `repo-url` needs to be removed.
